### PR TITLE
feat: Add robustness tests and fix uncovered bugs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -539,7 +539,7 @@ version = "2.0.0"
 description = "An implementation of lxml.xmlfile for the standard library"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -799,7 +799,7 @@ version = "2.3.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:852ae5bed3478b92f093e30f785c98e0cb62fa0a939ed057c31716e18a7a22b9"},
     {file = "numpy-2.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7a0e27186e781a69959d0230dd9909b5e26024f8da10683bd6344baea1885168"},
@@ -883,7 +883,7 @@ version = "3.1.5"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -910,7 +910,7 @@ version = "2.3.2"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pandas-2.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52bc29a946304c360561974c6542d1dd628ddafa69134a7131fdfd6a5d7a1a35"},
     {file = "pandas-2.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:220cc5c35ffaa764dd5bb17cf42df283b5cb7fdf49e10a7b053a06c9cb48ee2b"},
@@ -1421,7 +1421,7 @@ version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -2228,7 +2228,7 @@ version = "2025.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
     {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
@@ -2377,4 +2377,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "5883d5aee9afb665c242dbaa8c5fa58ab3b84ca607d5a3040e2280438bee2b38"
+content-hash = "1798565f845c0237f1477d53c7330125ff0ffa5a56972d0c118530d4ab6e9e5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ tenacity = ">=9.1.2,<10.0.0"
 pyyaml = ">=6.0.2,<7.0.0"
 pydantic-settings = "^2.0"
 requests = ">=2.32.3,<3.0.0"
-openpyxl = ">=3.1.4,<4.0.0"
 beautifulsoup4 = "^4.13.5"
 boto3 = ">=1.34.141,<2.0.0"
+pandas = "^2.2.2"
 
 
 [build-system]
@@ -56,6 +56,7 @@ pandas = "^2.2.2"
 moto = {extras = ["s3"], version = ">=5.1.1,<6.0.0"}
 types-boto3 = ">=1.34.141,<2.0.0"
 pytest-timeout = ">=2.3.1,<3.0.0"
+openpyxl = ">=3.1.4,<4.0.0"
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/py_load_epar/etl/orchestrator.py
+++ b/src/py_load_epar/etl/orchestrator.py
@@ -392,6 +392,11 @@ def run_etl(settings: Settings) -> None:
             staging_table=main_staging_table,
             pydantic_model=target_model,
             primary_key_columns=["epar_id"],
+            soft_delete_settings={
+                "column": "is_active",
+                "inactive_value": False,
+                "active_value": True,
+            },
         )
 
         # 6. Process documents only if there are records with a source URL

--- a/src/py_load_epar/etl/parser.py
+++ b/src/py_load_epar/etl/parser.py
@@ -54,18 +54,31 @@ def parse_ema_excel_file(
         if sheet is None:
             raise ValueError("Excel file contains no active sheets.")
 
-        # Read the header row and convert column names to snake_case
-        headers = [_snake_case(cell.value) for cell in sheet[1]]
+        # Get an iterator for all rows
+        rows_iterator = sheet.iter_rows(values_only=True)
+
+        # --- Get header row ---
+        try:
+            header_tuple = next(rows_iterator)
+        except StopIteration:
+            logger.warning("Excel sheet is empty. No data to parse.")
+            return # Empty sheet
+
+        # Check if header row is completely empty
+        if not any(header_tuple):
+            logger.warning("Excel sheet contains an empty header row. No data to parse.")
+            return
+
+        headers = [_snake_case(str(cell)) if cell is not None else "" for cell in header_tuple]
         logger.debug(f"Parsed Excel headers: {headers}")
 
+
         # --- Validate that all critical columns are present ---
-        # These are the raw column names expected from the source file,
-        # but snake_cased.
         required_columns = {
             "medicine_name",
             "product_number",
-            "authorization_status", # Use canonical 'z' spelling
-            "u_r_l",  # "URL" becomes "u_r_l" after snake_casing
+            "authorization_status",
+            "u_r_l",
         }
         missing_columns = required_columns - set(headers)
         if missing_columns:
@@ -73,14 +86,13 @@ def parse_ema_excel_file(
                 f"Missing critical columns from source file: {sorted(list(missing_columns))}"
             )
 
-        # Yield each subsequent row as a dictionary mapped by the headers
-        for row in sheet.iter_rows(min_row=2, values_only=True):
-            # Skip empty rows
+        # Yield each subsequent row as a dictionary
+        for row in rows_iterator:
             if not any(row):
                 continue
             yield dict(zip(headers, row))
 
-    except Exception as e:
+    except (IOError, TypeError, AttributeError) as e:
         logger.error(f"Failed to parse Excel file from {type(file_source)}. Error: {e}")
         # Re-raise the exception to be handled by the calling orchestrator
         raise

--- a/tests/etl/test_extract.py
+++ b/tests/etl/test_extract.py
@@ -46,6 +46,7 @@ def test_extract_data_renames_fields_correctly():
         # Arrange: Mock the parser to return a record with the "raw" field names
         mock_parse.return_value = iter([
             {
+                "product_number": "EMA/1",
                 "revision_date": datetime.date(2024, 1, 15),
                 "marketing_authorisation_holder_company_name": "Test MAH",
                 "active_substance": "Test Substance",
@@ -83,9 +84,9 @@ def test_extract_data_filters_by_high_water_mark():
 
         # Arrange: Mock the parser to return a list of records with various dates
         mock_parse.return_value = iter([
-                {"medicine_name": "OldMed", "revision_date": datetime.date(2024, 1, 15), "active_substance": "a"},
-                {"medicine_name": "SameDayMed", "revision_date": datetime.date(2024, 2, 15), "active_substance": "b"},
-                {"medicine_name": "NewMed", "revision_date": datetime.date(2024, 2, 16), "active_substance": "c"},
+                {"product_number": "EMA/1", "medicine_name": "OldMed", "revision_date": datetime.date(2024, 1, 15), "active_substance": "a"},
+                {"product_number": "EMA/2", "medicine_name": "SameDayMed", "revision_date": datetime.date(2024, 2, 15), "active_substance": "b"},
+                {"product_number": "EMA/3", "medicine_name": "NewMed", "revision_date": datetime.date(2024, 2, 16), "active_substance": "c"},
         ])
 
         # Act: Call the function and get the list of processed records

--- a/tests/etl/test_robustness.py
+++ b/tests/etl/test_robustness.py
@@ -1,6 +1,7 @@
 # Tests for the robustness of the ETL pipeline.
 # These tests cover scenarios like duplicate data, schema changes, and large data volumes.
 from pathlib import Path
+import unicodedata
 
 import pandas as pd
 import pytest
@@ -11,6 +12,313 @@ from py_load_epar.etl.orchestrator import run_etl
 
 # Mark all tests in this module as integration tests
 pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def sample_excel_file_with_pk_duplicates(tmp_path: Path) -> Path:
+    """
+    Creates a sample EMA data file with duplicate product numbers but different
+    revision dates.
+    """
+    file_path = tmp_path / "test_ema_data_with_pk_duplicates.xlsx"
+    data = {
+        "Category": ["Human", "Human", "Human"],
+        "Medicine name": ["TestMed A Old", "TestMed A New", "TestMed B"],
+        "Therapeutic area": ["Oncology", "Oncology", "Cardiology"],
+        "Active substance": ["substance_a", "substance_a", "substance_b"],
+        "Product number": ["EMA/1", "EMA/1", "EMA/2"],
+        "Patient safety": [None, None, None],
+        "authorization_status": ["Authorised", "Authorised", "Authorised"],
+        "ATC code": ["L01", "L01", "C01"],
+        "Additional monitoring": [None, None, None],
+        "Generic": [False, False, True],
+        "Biosimilar": [False, False, False],
+        "Conditional approval": [None, None, None],
+        "Exceptional circumstances": [None, None, None],
+        "Marketing authorisation date": ["2023-01-01", "2023-01-01", "2023-01-02"],
+        "Revision date": ["2023-01-15", "2023-01-20", "2023-01-16"],
+        "Marketing authorisation holder/company name": ["PharmaCo", "PharmaCo", "BioGen"],
+        "URL": ["http://example.com/1", "http://example.com/1", "http://example.com/2"],
+    }
+    df = pd.DataFrame(data)
+    df.to_excel(file_path, index=False, sheet_name="Medicines for human use")
+    return file_path
+
+
+def test_etl_with_duplicate_product_numbers(
+    postgres_adapter: PostgresAdapter,
+    db_settings: Settings,
+    mocker,
+    sample_excel_file_with_pk_duplicates: Path,
+):
+    """
+    Tests that if the source file contains duplicate product numbers, only the one
+    with the latest revision date is loaded.
+    """
+    # --- Mock dependencies ---
+    mocker.patch(
+        "py_load_epar.etl.extract.download_file_to_memory",
+        return_value=sample_excel_file_with_pk_duplicates.open("rb"),
+    )
+    mock_spor_client = mocker.patch("py_load_epar.etl.orchestrator.SporApiClient")
+    mock_spor_client.return_value.search_organisation.return_value = None
+    mock_spor_client.return_value.search_substance.return_value = None
+    mocker.patch("py_load_epar.etl.orchestrator._process_documents", return_value=0)
+
+    # --- Run the ETL process ---
+    settings = db_settings
+    settings.etl.load_strategy = "FULL"
+    run_etl(settings)
+
+    # --- Assertions ---
+    with postgres_adapter.conn.cursor() as cursor:
+        # Verify that only 2 records were loaded (the latest EMA/1 and EMA/2)
+        cursor.execute("SELECT COUNT(*) FROM epar_index")
+        assert cursor.fetchone()[0] == 2
+
+        # Verify that the correct version of EMA/1 is in the database
+        cursor.execute("SELECT medicine_name FROM epar_index WHERE epar_id = 'EMA/1'")
+        assert cursor.fetchone()[0] == "TestMed A New"
+
+
+@pytest.fixture
+def sample_excel_file_with_special_chars(tmp_path: Path) -> Path:
+    """Creates a sample EMA data file with special (non-ASCII) characters."""
+    file_path = tmp_path / "test_ema_data_with_special_chars.xlsx"
+    data = {
+        "Category": ["Human"],
+        "Medicine name": ["Médicament Test Bø"],
+        "Therapeutic area": ["Gastroentérologie"],
+        "Active substance": ["substance_ß"],
+        "Product number": ["EMA/SPECIAL"],
+        "Patient safety": [None],
+        "authorization_status": ["Authorised"],
+        "ATC code": ["A02"],
+        "Additional monitoring": [None],
+        "Generic": [False],
+        "Biosimilar": [False],
+        "Conditional approval": [None],
+        "Exceptional circumstances": [None],
+        "Marketing authorisation date": ["2023-01-01"],
+        "Revision date": ["2023-01-15"],
+        "Marketing authorisation holder/company name": ["Crème Brûlée Pharma"],
+        "URL": ["http://example.com/special"],
+    }
+    df = pd.DataFrame(data)
+    df.to_excel(file_path, index=False, sheet_name="Medicines for human use")
+    return file_path
+
+
+def test_etl_with_special_characters(
+    postgres_adapter: PostgresAdapter,
+    db_settings: Settings,
+    mocker,
+    sample_excel_file_with_special_chars: Path,
+):
+    """
+    Tests that the ETL pipeline correctly handles non-ASCII characters.
+    """
+    # --- Mock dependencies ---
+    mocker.patch(
+        "py_load_epar.etl.extract.download_file_to_memory",
+        return_value=sample_excel_file_with_special_chars.open("rb"),
+    )
+    mock_spor_client = mocker.patch("py_load_epar.etl.orchestrator.SporApiClient")
+    mock_spor_client.return_value.search_organisation.return_value = None
+    mock_spor_client.return_value.search_substance.return_value = None
+    mocker.patch("py_load_epar.etl.orchestrator._process_documents", return_value=0)
+
+    # --- Run the ETL process ---
+    settings = db_settings
+    settings.etl.load_strategy = "FULL"
+    run_etl(settings)
+
+    # --- Assertions ---
+    with postgres_adapter.conn.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM epar_index")
+        assert cursor.fetchone()[0] == 1
+
+        cursor.execute(
+            """
+            SELECT medicine_name, therapeutic_area, active_substance_raw,
+                   marketing_authorization_holder_raw
+            FROM epar_index WHERE epar_id = 'EMA/SPECIAL'
+            """
+        )
+        row = cursor.fetchone()
+        assert unicodedata.normalize("NFC", row[0]) == unicodedata.normalize(
+            "NFC", "Médicament Test Bø"
+        )
+        assert unicodedata.normalize("NFC", row[1]) == unicodedata.normalize(
+            "NFC", "Gastroentérologie"
+        )
+        assert unicodedata.normalize("NFC", row[2]) == unicodedata.normalize(
+            "NFC", "substance_ß"
+        )
+        assert unicodedata.normalize("NFC", row[3]) == unicodedata.normalize(
+            "NFC", "Crème Brûlée Pharma"
+        )
+
+
+@pytest.fixture
+def empty_excel_file(tmp_path: Path) -> Path:
+    """Creates a completely empty Excel file."""
+    file_path = tmp_path / "empty_ema_data.xlsx"
+    df = pd.DataFrame()
+    df.to_excel(file_path, index=False, sheet_name="Medicines for human use")
+    return file_path
+
+
+def test_etl_with_empty_file(
+    postgres_adapter: PostgresAdapter,
+    db_settings: Settings,
+    mocker,
+    empty_excel_file: Path,
+    caplog,
+):
+    """
+    Tests that the ETL pipeline runs without error on an empty input file.
+    """
+    # --- Mock dependencies ---
+    mocker.patch(
+        "py_load_epar.etl.extract.download_file_to_memory",
+        return_value=empty_excel_file.open("rb"),
+    )
+    mock_spor_client = mocker.patch("py_load_epar.etl.orchestrator.SporApiClient")
+    mocker.patch("py_load_epar.etl.orchestrator._process_documents", return_value=0)
+
+    # --- Run the ETL process ---
+    settings = db_settings
+    settings.etl.load_strategy = "FULL"
+    run_etl(settings)
+
+    # --- Assertions ---
+    # Verify that the ETL process completed successfully and logged the correct warning
+    assert "Excel sheet is empty. No data to parse." in caplog.text
+
+    # Verify no data was loaded
+    with postgres_adapter.conn.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM epar_index")
+        assert cursor.fetchone()[0] == 0
+
+    # Verify that the SPOR client was not called
+    mock_spor_client.return_value.search_organisation.assert_not_called()
+
+
+@pytest.fixture
+def delta_load_files(tmp_path: Path) -> tuple[Path, Path]:
+    """
+    Creates two Excel files to simulate a DELTA load scenario where one record
+    is removed in the second run.
+    """
+    # File for the first run (initial load)
+    file1_path = tmp_path / "delta_run1.xlsx"
+    data1 = {
+        "Category": ["Human", "Human"],
+        "Medicine name": ["TestMed A", "TestMed B (to be removed)"],
+        "Therapeutic area": ["Oncology", "Cardiology"],
+        "Active substance": ["substance_a", "substance_b"],
+        "Product number": ["EMA/DELTA/1", "EMA/DELTA/2"],
+        "Patient safety": [None, None],
+        "authorization_status": ["Authorised", "Authorised"],
+        "ATC code": ["L01", "C01"],
+        "Additional monitoring": [None, None],
+        "Generic": [False, True],
+        "Biosimilar": [False, False],
+        "Conditional approval": [None, None],
+        "Exceptional circumstances": [None, None],
+        "Marketing authorisation date": ["2023-01-01", "2023-01-02"],
+        "Revision date": ["2023-01-15", "2023-01-16"],
+        "Marketing authorisation holder/company name": ["PharmaCo", "BioGen"],
+        "URL": ["http://example.com/delta1", "http://example.com/delta2"],
+    }
+    df1 = pd.DataFrame(data1)
+    df1.to_excel(file1_path, index=False, sheet_name="Medicines for human use")
+
+    # File for the second run (record for EMA/DELTA/2 is removed)
+    file2_path = tmp_path / "delta_run2.xlsx"
+    data2 = {
+        "Category": ["Human"],
+        "Medicine name": ["TestMed A (updated)"],
+        "Therapeutic area": ["Oncology"],
+        "Active substance": ["substance_a"],
+        "Product number": ["EMA/DELTA/1"],
+        "Patient safety": [None],
+        "authorization_status": ["Authorised"],
+        "ATC code": ["L01"],
+        "Additional monitoring": [None],
+        "Generic": [False],
+        "Biosimilar": [False],
+        "Conditional approval": [None],
+        "Exceptional circumstances": [None],
+        "Marketing authorisation date": ["2023-01-01"],
+        "Revision date": ["2023-01-18"], # Note the updated revision date
+        "Marketing authorisation holder/company name": ["PharmaCo"],
+        "URL": ["http://example.com/delta1"],
+    }
+    df2 = pd.DataFrame(data2)
+    df2.to_excel(file2_path, index=False, sheet_name="Medicines for human use")
+
+    return file1_path, file2_path
+
+
+def test_delta_load_soft_delete(
+    postgres_adapter: PostgresAdapter,
+    db_settings: Settings,
+    mocker,
+    delta_load_files: tuple[Path, Path],
+):
+    """
+    Tests that a DELTA load correctly performs a soft-delete on records that
+    are no longer present in the source.
+    """
+    file1, file2 = delta_load_files
+
+    # --- Mock dependencies ---
+    mock_download = mocker.patch("py_load_epar.etl.extract.download_file_to_memory")
+    mock_spor_client = mocker.patch("py_load_epar.etl.orchestrator.SporApiClient")
+    mock_spor_client.return_value.search_organisation.return_value = None
+    mock_spor_client.return_value.search_substance.return_value = None
+    mocker.patch("py_load_epar.etl.orchestrator._process_documents", return_value=0)
+
+    # --- 1. First Run (FULL load to establish baseline) ---
+    mock_download.return_value = file1.open("rb")
+    settings = db_settings
+    settings.etl.load_strategy = "FULL"
+    run_etl(settings)
+
+    # --- Assert initial state ---
+    with postgres_adapter.conn.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM epar_index WHERE is_active = TRUE")
+        assert cursor.fetchone()[0] == 2
+        cursor.execute(
+            "SELECT is_active FROM epar_index WHERE epar_id = 'EMA/DELTA/2'"
+        )
+        assert cursor.fetchone()[0] is True
+
+    # --- 2. Second Run (DELTA load with one record removed) ---
+    mock_download.return_value = file2.open("rb")
+    settings.etl.load_strategy = "DELTA"
+    run_etl(settings)
+
+    # --- Assert final state ---
+    with postgres_adapter.conn.cursor() as cursor:
+        # Verify total records is still 2
+        cursor.execute("SELECT COUNT(*) FROM epar_index")
+        assert cursor.fetchone()[0] == 2
+        # Verify only 1 is active
+        cursor.execute("SELECT COUNT(*) FROM epar_index WHERE is_active = TRUE")
+        assert cursor.fetchone()[0] == 1
+        # Verify the correct record was soft-deleted
+        cursor.execute(
+            "SELECT is_active FROM epar_index WHERE epar_id = 'EMA/DELTA/2'"
+        )
+        assert cursor.fetchone()[0] is False
+        # Verify the other record is still active
+        cursor.execute(
+            "SELECT is_active FROM epar_index WHERE epar_id = 'EMA/DELTA/1'"
+        )
+        assert cursor.fetchone()[0] is True
 
 
 @pytest.fixture


### PR DESCRIPTION
- Adds a new test file `tests/etl/test_robustness.py` with tests for:
    - Handling of duplicate `product_number`s.
    - Character encoding issues.
    - Empty input files.
    - Soft-deletes in DELTA loads.
- Fixes several bugs uncovered by these new tests:
    - Deduplication logic now correctly uses the `Revision date`.
    - Empty Excel files are now handled gracefully.
    - Soft-delete logic now works correctly for DELTA loads.
- Fixes regressions in existing tests caused by the changes.